### PR TITLE
IMAP SSL, FreeBSD

### DIFF
--- a/imap.c
+++ b/imap.c
@@ -10,6 +10,9 @@
 #include <poll.h>
 #include <signal.h>
 #include <sys/wait.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
 #ifdef USE_OPENSSL
 #include <openssl/ssl.h>
 #include <openssl/err.h>

--- a/imapinterface.c
+++ b/imapinterface.c
@@ -23,7 +23,8 @@ struct imap_ll *imapc;
 		ERR_print_errors_fp(stderr);
 		return NULL;
 	}
-	SSL_CTX_load_verify_locations(sslctx, NULL, "/etc/ssl/certs");
+	SSL_CTX_set_default_verify_paths(sslctx);
+	SSL_CTX_load_verify_locations(sslctx, NULL, NULL); 
 	SSL_CTX_set_verify(sslctx, SSL_VERIFY_PEER, NULL);
 #endif
 

--- a/imapinterface.c
+++ b/imapinterface.c
@@ -1,7 +1,11 @@
 #include <stdio.h>
 #include <string.h>
+
+#ifdef USE_OPENSSL
 #include <openssl/ssl.h>
 #include <openssl/err.h>
+#endif
+
 #include "imapinterface.h"
 #include "imap.h"
 #include "mairix.h"

--- a/imapinterface.c
+++ b/imapinterface.c
@@ -21,7 +21,8 @@ struct imap_ll *imapc;
 #ifdef USE_OPENSSL
 	SSL_load_error_strings();
 	SSL_library_init();
-	sslctx = SSL_CTX_new(SSLv23_client_method());
+	sslctx = SSL_CTX_new(TLSv1_client_method());
+        SSL_CTX_set_options(sslctx, SSL_OP_NO_SSL_MASK); 
 	if (!sslctx) {
 		fprintf(stderr, "SSL_CTX_new failed\n");
 		ERR_print_errors_fp(stderr);
@@ -224,6 +225,7 @@ const char *actual_uidvalidity, *got_uid, *got_raw;
 		l2 = l2->next;
 		if (l2->type != TLTYPE_LIST) continue;
 		got_uid = got_raw = NULL;
+                got_uid_len = raw_len = 0;
 		for (l2 = l2->first; l2 && (l2->next); l2 = l2->next) {
 			if (l2->type != TLTYPE_ATOM) continue;
 			if (0 == strcmp(l2->leaf, "UID")) {

--- a/mairix.c
+++ b/mairix.c
@@ -230,9 +230,10 @@ static void parse_rc_file(char *name)/*{{{*/
       line[len-1] = '\0';
     }
 
-    /* Strip trailing comments. */
-    for (p=line; *p && !strchr("#!;%", *p); p++) ;
-    if (*p) *p = '\0';
+    /* Discard comment lines. */
+    if (strchr("#", line[0])) {
+       continue;
+    }
 
     /* Discard blank lines */
     all_blank = 1;

--- a/mairixrc.5
+++ b/mairixrc.5
@@ -47,7 +47,7 @@ or
 directives.
 
 .SS Comments
-Any line starting with a '#' character is treated as a comment.
+Any line starting with a '#' character is treated as a comment.  Trailing comments are not allowed.
 
 .SS Directives
 .TP

--- a/test/scripts/generate_big_message.sh
+++ b/test/scripts/generate_big_message.sh
@@ -109,8 +109,24 @@ esac
 generate_message >"$FILE"
 
 #asserting the message has the correct size
-if test "$SIZE" != "$(stat -c%s "$FILE")"
-then
-    rm -f "$FILE"
-    exit 1
-fi
+# FreeBSD stat uses "-f" for output formatting, GNU uses "-c"
+# FreeBSD stat use "%z" for total size in bytes, GNU uses "%s"
+case $(uname -s) in
+  Linux )
+    if test "$SIZE" != "$(stat -c%s "$FILE")"
+    then
+        rm -f "$FILE"
+        exit 1
+    fi
+  ;;
+  FreeBSD )
+    if test "$SIZE" != "$(stat -f%z "$FILE")"
+        then
+            rm -f "$FILE"
+            exit 1
+    fi
+  ;;
+  *)
+     echo "Unknown OS: $(uname -s)"
+  ;;
+esac


### PR DESCRIPTION
These changes include additional headers to build on FreeBSD 11, use the default location for SSL certificates when verifying an IMAP server certificate, and how comments in mairixrc are handled.  

This last change makes the program compatible with the manual page and allows for using special characters in passwords -- the previous behavior would strip passwords from a special character to the end of the line.  I've added text to the mairixrc manual page to clarify that trailing comments are not allowed.

SSL certificates are now loaded from the system default location, or a location specified by the user's  environment.

Also included is some preliminary work to allow the tests to run on FreeBSD; there is more to do, here, due to differences in BSD versus GNU utilities options.