### PR TITLE
Reflow mairixrc(5) to avoid warning: macro `imap_pipe'' not defined

### DIFF
--- a/mairixrc.5
+++ b/mairixrc.5
@@ -61,8 +61,8 @@ maildir folders.
 .br
 If any IMAP source folders are specified or the results folder is an IMAP
 folder, this defines the host name of the IMAP server. The port is
-currently always 143. This option is mutually exclusive with the
-'imap_pipe' option.
+currently always 143. This option is mutually exclusive with the 'imap_pipe'
+option.
 
 .TP
 .BI imap_pipe= shell-command


### PR DESCRIPTION
Caught by Debian's lintian tool.