### PR TITLE
Support searching arbitrary headers

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -50,7 +50,7 @@ docdir=$(DESTDIR)@docdir@
 OBJ = mairix.o db.o rfc822.o tok.o hash.o dirscan.o writer.o \
       reader.o search.o stats.o dates.o datescan.o mbox.o md5.o \
   	  fromcheck.o glob.o dumper.o expandstr.o dotlock.o \
-			nvp.o nvpscan.o imap.o imapinterface.o
+			nvp.o nvpscan.o imap.o imapinterface.o headers.o
 
 all : mairix
 
@@ -74,8 +74,8 @@ mbox.o : fromcheck.h
 nvp.o : nvpscan.h
 
 mairix.o : imapinterface.h
-db.o : imapinterface.h
-search.o : imapinterface.h
+db.o : imapinterface.h headers.h headers.c
+search.o : imapinterface.h headers.h headers.c
 
 imap.o : imap.c imap.h
 imapinterface.o : imapinterface.c imapinterface.h imap.h

--- a/dumper.c
+++ b/dumper.c
@@ -36,15 +36,22 @@
 #include "mairix.h"
 #include "reader.h"
 #include "memmac.h"
+#include "headers.h"
 
 static void dump_token_chain(struct read_db *db, unsigned int n, unsigned int *tok_offsets, unsigned int *enc_offsets)
 {
   int i, j, incr;
   int on_line;
   unsigned char *foo;
+  char *prefix, *token;
   printf("%d entries\n", n);
   for (i=0; i<n; i++) {
-    printf("Word %d : <%s>\n", i, db->data + tok_offsets[i]);
+    token = db->data + tok_offsets[i];
+    prefix = resolve_prefix(token);
+    if (prefix)
+      printf("Word %d : <%s:%s>\n", i, prefix, token + 2);
+    else
+      printf("Word %d : <%s>\n", i, token);
     foo = (unsigned char *) db->data + enc_offsets[i];
     j = 0;
     on_line = 0;
@@ -145,6 +152,8 @@ void dump_database(char *filename)
   dump_toktable(db, &db->body, "Body");
   printf("--------------------------------\n");
   dump_toktable(db, &db->attachment_name, "Attachment names");
+  printf("--------------------------------\n");
+  dump_toktable(db, &db->minor_headers, "Minor headers");
   printf("--------------------------------\n");
   dump_toktable2(db, &db->msg_ids, "Message Ids");
   printf("--------------------------------\n");

--- a/headers.c
+++ b/headers.c
@@ -1,0 +1,119 @@
+#include <stddef.h>
+#include <string.h>
+
+#include "headers.h"
+
+/**
+ * Table of single-character abbreviations for common headers. There are a lot
+ * of other headers that are very common that could be added to this list, but
+ * they are specific to certain email service providers and / or mail servers.
+ */
+char *common_prefix_table[256] = {
+    [1] = "accept-language",
+    [2] = "arc-authentication-results",
+    [3] = "arc-message-signature",
+    [4] = "arc-seal",
+    [5] = "authentication-results",
+    [6] = "content-disposition",
+    [7] = "content-id",
+    [8] = "content-language",
+    [9] = "content-length",
+   [10] = "content-transfer-encoding",
+   [11] = "content-type",
+   [12] = "delivered-to",
+   [13] = "dkim-signature",
+   [14] = "in-reply-to",
+   [15] = "list-archive",
+   [16] = "list-id",
+   [17] = "list-post",
+   [18] = "list-unsubscribe",
+   [19] = "message-id",
+   [20] = "mime-version",
+   [21] = "precedence",
+   [22] = "received-spf",
+   [23] = "received",
+   [24] = "references",
+   [25] = "reply-to",
+   [26] = "return-path",
+   [27] = "sender",
+   [28] = "thread-index",
+   [29] = "thread-topic",
+   [30] = "user-agent",
+   [31] = "x-auto-response-suppress",
+   [32] = "x-feedback-id",
+
+  /* ASCII values 33 through 126 are valid RFC 822 field name characters. */
+
+  [126] = "x-mailer",
+  [127] = "x-originating-ip",
+  [128] = "x-originatororg",
+  [129] = "x-priority",
+  [130] = "x-received",
+  [131] = "x-sasl-enc",
+
+  [255] = NULL, /* 0xff is used as the token terminator in the database. */
+};
+
+/**
+ * If a token has an abbreviated prefix, return the human-readable version.
+ * Otherwise, NULL is returned.
+ */
+inline char *resolve_prefix(char *token_in_database)
+{
+  return common_prefix_table[(unsigned char) *token_in_database];
+}
+
+/**
+ * Return a token stripped of its prefix. The `accepted_prefixes` is a NULL
+ * terminated array of strings. If the `accepted_prefixes` is defined, a NULL
+ * is returned if the token prefix is not present in that list.
+ */
+inline char *token_without_prefix(char *token, char **accepted_prefixes)
+{
+  char *prefix;
+  char *colon;
+  char **entry;
+
+  if (!accepted_prefixes) return strchr(token, ':') + 1;
+
+  if ((prefix = common_prefix_table[(unsigned char) *token])) {
+    colon = token + 2;
+    for (entry = accepted_prefixes; *entry; entry++)
+      if (!strcasecmp(*entry, prefix))
+        return token + 2;
+  } else {
+    colon = strchr(token, ':');
+    for (entry = accepted_prefixes; *entry; entry++)
+      if (!strncasecmp(*entry, token, colon - token) && (*entry)[colon - token] == '\0')
+        return colon + 1;
+  }
+
+  return NULL;
+}
+
+/**
+ * Attempt to compress a token prefix and returned the resulting value.
+ */
+inline char *compress_prefix(char *prefix)
+{
+  static char result[3];
+
+  for (int i = 1; i < 256; i++) {
+    if (common_prefix_table[i] && !strcasecmp(prefix, common_prefix_table[i])) {
+      result[0] = '\0' + i;
+      result[1] = '\0';
+      return result;
+    }
+  }
+
+  return prefix;
+}
+
+/**
+ * Indicates whether or not a table uses prefixes. This exists mostly for
+ * readability since only the minor headers table uses prefixes.
+ */
+inline int table_tokens_have_prefixes(struct read_db *db, struct toktable_db *tt)
+{
+  return tt == &db->minor_headers;
+}

--- a/headers.h
+++ b/headers.h
@@ -1,0 +1,14 @@
+#ifndef HEADERS_H
+#define HEADERS_H
+
+#include "mairix.h"
+#include "reader.h"
+
+extern char *common_prefix_table[256];
+
+char *compress_prefix(char *prefix);
+char *resolve_prefix(char *token_in_database);
+char *token_without_prefix(char *token, char **accepted_prefixes);
+int table_tokens_have_prefixes(struct read_db *db, struct toktable_db *tt);
+
+#endif

--- a/mairix.c
+++ b/mairix.c
@@ -42,6 +42,7 @@ int total_bytes=0;
 
 int verbose = 0;
 int do_hardlinks = 0;
+int do_index_all_headers = 0;
 
 static char *folder_base = NULL;
 static char *maildir_folders = NULL;
@@ -273,6 +274,7 @@ static void parse_rc_file(char *name)/*{{{*/
     else if (!strncasecmp(p, "mfolder=", 8)) mfolder = copy_value(p);
     else if (!strncasecmp(p, "database=", 9)) database_path = copy_value(p);
     else if (!strncasecmp(p, "nochecks", 8)) skip_integrity_checks = 1;
+    else if (!strncasecmp(p, "index_all_headers", 17)) do_index_all_headers = 1;
     else {
       if (verbose) {
         fprintf(stderr, "Unrecognized option at line %d in %s\n", lineno, name);
@@ -476,6 +478,8 @@ static void usage(void)/*{{{*/
          "    p:substring   : match substring of path\n"
          "    d:start-end   : match date range\n"
          "    z:low-high    : match messages in size range\n"
+         "    h:word        : match word in the value of any minor header\n"
+         "    h:X:Y:word    : match word in the value of minor headers named \"X\" or \"Y\"\n"
          "    bs:word       : match word in Subject: header or body (or any other group of prefixes)\n"
          "    s:word1,word2 : match both words in Subject:\n"
          "    s:word1/word2 : match either word or both words in Subject:\n"

--- a/mairix.h
+++ b/mairix.h
@@ -152,11 +152,19 @@ struct attachment {/*{{{*/
   } data;
 };
 /*}}}*/
+struct header_name_value {/*{{{*/
+  struct header_name_value *next;
+  char *name;
+  char *value;
+};
+/*}}}*/
 struct headers {/*{{{*/
   char *to;
   char *cc;
   char *from;
   char *subject;
+
+  struct header_name_value *minor_headers;
 
   /* The following are needed to support threading */
   char *message_id;
@@ -248,6 +256,7 @@ struct database {/*{{{*/
   struct toktable *subject;
   struct toktable *body;
   struct toktable *attachment_name;
+  struct toktable *minor_headers;
 
   /* Encoding chain 0 stores all msgids appearing in the following message headers:
    * Message-Id, In-Reply-To, References.  Used for thread reconciliation.
@@ -290,6 +299,7 @@ extern struct traverse_methods mbox_traverse_methods;
 
 extern int verbose; /* cmd line -v switch */
 extern int do_hardlinks; /* cmd line -H switch */
+extern int do_index_all_headers; /* "index_all_headers" configuration option */
 
 /* Lame fix for systems where NAME_MAX isn't defined after including the above
  * set of .h files (Solaris, FreeBSD so far).  Probably grossly oversized but

--- a/reader.c
+++ b/reader.c
@@ -174,6 +174,7 @@ struct read_db *open_db(char *filename)/*{{{*/
   read_toktable_db(data, &result->subject, UI_SUBJECT_BASE, uidata);
   read_toktable_db(data, &result->body, UI_BODY_BASE, uidata);
   read_toktable_db(data, &result->attachment_name, UI_ATTACHMENT_NAME_BASE, uidata);
+  read_toktable_db(data, &result->minor_headers, UI_MINOR_HEADERS_BASE, uidata);
   read_toktable2_db(data, &result->msg_ids, UI_MSGID_BASE, uidata);
 
   return result;
@@ -197,6 +198,7 @@ void close_db(struct read_db *x)/*{{{*/
   free_toktable_db(&x->subject);
   free_toktable_db(&x->body);
   free_toktable_db(&x->attachment_name);
+  free_toktable_db(&x->minor_headers);
   free_toktable2_db(&x->msg_ids);
 
   if (munmap(x->data, x->len) < 0) {

--- a/reader.h
+++ b/reader.h
@@ -27,7 +27,7 @@
 #define HEADER_MAGIC0 'M'
 #define HEADER_MAGIC1 'X'
 #define HEADER_MAGIC2 0xA5
-#define HEADER_MAGIC3 0x03
+#define HEADER_MAGIC3 0x04
 
 /*{{{ Constants for file data positions */
 #define UI_ENDIAN          1
@@ -75,10 +75,11 @@
 #define UI_SUBJECT_BASE   25
 #define UI_BODY_BASE      28
 #define UI_ATTACHMENT_NAME_BASE 31
-#define UI_MSGID_BASE     34
+#define UI_MINOR_HEADERS_BASE 34
+#define UI_MSGID_BASE     37
 
 /* Larger than the last table offset. */
-#define UI_HEADER_LEN     40
+#define UI_HEADER_LEN     43
 #define UC_HEADER_LEN     ((UI_HEADER_LEN) << 2)
 
 #define UI_N_OFFSET        0
@@ -103,6 +104,9 @@
 #define UI_ATTACHMENT_NAME_N    (UI_ATTACHMENT_NAME_BASE + UI_N_OFFSET)
 #define UI_ATTACHMENT_NAME_TOK  (UI_ATTACHMENT_NAME_BASE + UI_TOK_OFFSET)
 #define UI_ATTACHMENT_NAME_ENC  (UI_ATTACHMENT_NAME_BASE + UI_ENC_OFFSET)
+#define UI_MINOR_HEADERS_N    (UI_MINOR_HEADERS_BASE + UI_N_OFFSET)
+#define UI_MINOR_HEADERS_TOK  (UI_MINOR_HEADERS_BASE + UI_TOK_OFFSET)
+#define UI_MINOR_HEADERS_ENC  (UI_MINOR_HEADERS_BASE + UI_ENC_OFFSET)
 #define UI_MSGID_N        (UI_MSGID_BASE + UI_N_OFFSET)
 #define UI_MSGID_TOK      (UI_MSGID_BASE + UI_TOK_OFFSET)
 #define UI_MSGID_ENC0     (UI_MSGID_BASE + UI_ENC_OFFSET)
@@ -167,6 +171,7 @@ struct read_db {/*{{{*/
   struct toktable_db body;
   struct toktable_db attachment_name;
   struct toktable2_db msg_ids;
+  struct toktable_db minor_headers;
 
 };
 /*}}}*/

--- a/search.c
+++ b/search.c
@@ -45,6 +45,7 @@
 #include "reader.h"
 #include "memmac.h"
 #include "imapinterface.h"
+#include "headers.h"
 
 static void mark_hits_in_table(struct read_db *db, struct toktable_db *tt, int hit_tok, char *hits)/*{{{*/
 {
@@ -247,7 +248,7 @@ static int substring_match_general(unsigned long *a, unsigned long hit, int left
 }
 /*}}}*/
 
-static void match_substring_in_table(struct read_db *db, struct toktable_db *tt, char *substring, int max_errors, int left_anchor, char *hits)/*{{{*/
+static void match_substring_in_table(struct read_db *db, struct toktable_db *tt, char *substring, int max_errors, int left_anchor, char *hits, char **accepted_prefixes)/*{{{*/
 {
 
   int i, got_hit;
@@ -265,6 +266,10 @@ static void match_substring_in_table(struct read_db *db, struct toktable_db *tt,
   }
   for (i=0; i<tt->n; i++) {
     token = db->data + tt->tok_offsets[i];
+
+    if (table_tokens_have_prefixes(db, tt) && !(token = token_without_prefix(token, accepted_prefixes)))
+      continue;
+
     switch (max_errors) {
       /* Optimise common cases for few errors to allow optimizer to keep bitmaps
        * in registers */
@@ -351,13 +356,19 @@ next_message:
   if (nr) free(nr);
 }
 /*}}}*/
-static void match_string_in_table(struct read_db *db, struct toktable_db *tt, char *key, char *hits)/*{{{*/
+static void match_string_in_table(struct read_db *db, struct toktable_db *tt, char *key, char *hits, char **accepted_prefixes)/*{{{*/
 {
   /* TODO : replace with binary search? */
   int i;
+  char *token;
 
   for (i=0; i<tt->n; i++) {
-    if (!strcmp(key, db->data + tt->tok_offsets[i])) {
+    token = db->data + tt->tok_offsets[i];
+
+    if (table_tokens_have_prefixes(db, tt) && !(token = token_without_prefix(token, accepted_prefixes)))
+      continue;
+
+    if (!strcmp(key, token)) {
       /* get all matching files */
       mark_hits_in_table(db, tt, i, hits);
     }
@@ -787,7 +798,7 @@ static void string_tolower(char *str)
 static int do_search(struct read_db *db, char **args, char *output_path, int show_threads, enum folder_type ft, int verbose, const char *imap_pipe, const char *imap_server, const char *imap_username, const char *imap_password, int please_clear)/*{{{*/
 {
   char *colon, *start_words;
-  int do_body, do_subject, do_from, do_to, do_cc, do_date, do_size;
+  int do_body, do_subject, do_from, do_to, do_cc, do_date, do_size, do_minor_headers;
   int do_att_name;
   int do_flags;
   int do_path, do_msgid;
@@ -798,6 +809,7 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
   int left_anchor;
   int imap_tried = 0;
   struct imap_ll *imapc;
+  int did_minor_headers = 0;
 
 #define GET_IMAP if (!imap_tried) {\
         imap_tried = 1;\
@@ -850,6 +862,7 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
     do_msgid = 0;
     do_att_name = 0;
     do_flags = 0;
+    do_minor_headers = 0;
 
     colon = strchr(key, ':');
 
@@ -870,6 +883,7 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
           case 'm': do_msgid = 1; break;
           case 'n': do_att_name = 1; break;
           case 'F': do_flags = 1; break;
+          case 'h': do_minor_headers = 1; break;
           default: fprintf(stderr, "Unknown key type <%c>\n", *p); break;
         }
       }
@@ -920,6 +934,8 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
       int negate;
       int had_orsep;
       int max_errors;
+      char **header_list = NULL;
+      char *last_colon;
 
       orsep = strchr(start_words, '/');
       andsep  = strchr(start_words, ',');
@@ -954,6 +970,41 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
 
       orig_word = word;
 
+      last_colon = strrchr(word, ':');
+
+      if (last_colon) {
+        if (!do_minor_headers && !do_att_name) {
+          fprintf(stderr, "A colon can only be used in queries for attachment "
+                  "filenames and minor header values.\n");
+          unlock_and_exit(2);
+        }
+
+        if (do_minor_headers && do_att_name) {
+          fprintf(stderr, "A colon cannot appear in a pattern argument that "
+                  "searches minor header values and attachment names.\n");
+          unlock_and_exit(2);
+        }
+
+        /* Colons a list of colon delimited header names can be used to
+         * restrict which headers are searched for an expression. */
+        if (do_minor_headers) {
+          size_t n = 0;
+          char *cursor;
+          header_list = new_array(char *, strlen(word) / 2 + 1); /* worst-case allocation */
+          *last_colon = '\0';
+
+          for (cursor = word; *cursor && cursor < last_colon; cursor++) {
+            if (*cursor == ':')
+              *cursor = '\0';
+            else if (cursor == word || (*cursor != '\0' && *(cursor - 1) == '\0'))
+              header_list[n++] = cursor;
+          }
+
+          header_list[n] = NULL;
+          word = last_colon + 1;
+        }
+      }
+
       if (word[0] == '~') {
         negate = 1;
         word++;
@@ -985,25 +1036,30 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
 
       memset(hit0, 0, db->n_msgs);
       if (equal) {
-        if (do_to) match_substring_in_table(db, &db->to, lower_word, max_errors, left_anchor, hit0);
-        if (do_cc) match_substring_in_table(db, &db->cc, lower_word, max_errors, left_anchor, hit0);
-        if (do_from) match_substring_in_table(db, &db->from, lower_word, max_errors, left_anchor, hit0);
-        if (do_subject) match_substring_in_table(db, &db->subject, lower_word, max_errors, left_anchor, hit0);
-        if (do_body) match_substring_in_table(db, &db->body, lower_word, max_errors, left_anchor, hit0);
-        if (do_att_name) match_substring_in_table(db, &db->attachment_name, lower_word, max_errors, left_anchor, hit0);
+        if (do_to) match_substring_in_table(db, &db->to, lower_word, max_errors, left_anchor, hit0, NULL);
+        if (do_cc) match_substring_in_table(db, &db->cc, lower_word, max_errors, left_anchor, hit0, NULL);
+        if (do_from) match_substring_in_table(db, &db->from, lower_word, max_errors, left_anchor, hit0, NULL);
+        if (do_subject) match_substring_in_table(db, &db->subject, lower_word, max_errors, left_anchor, hit0, NULL);
+        if (do_body) match_substring_in_table(db, &db->body, lower_word, max_errors, left_anchor, hit0, NULL);
+        if (do_att_name) match_substring_in_table(db, &db->attachment_name, lower_word, max_errors, left_anchor, hit0, NULL);
+        if (do_minor_headers) match_substring_in_table(db, &db->minor_headers, lower_word, max_errors, left_anchor, hit0, header_list);
         if (do_path) match_substring_in_paths(db, word, max_errors, left_anchor, hit0);
       } else {
-        if (do_to) match_string_in_table(db, &db->to, lower_word, hit0);
-        if (do_cc) match_string_in_table(db, &db->cc, lower_word, hit0);
-        if (do_from) match_string_in_table(db, &db->from, lower_word, hit0);
-        if (do_subject) match_string_in_table(db, &db->subject, lower_word, hit0);
-        if (do_body) match_string_in_table(db, &db->body, lower_word, hit0);
-        if (do_att_name) match_string_in_table(db, &db->attachment_name, lower_word, hit0);
+        if (do_to) match_string_in_table(db, &db->to, lower_word, hit0, NULL);
+        if (do_cc) match_string_in_table(db, &db->cc, lower_word, hit0, NULL);
+        if (do_from) match_string_in_table(db, &db->from, lower_word, hit0, NULL);
+        if (do_subject) match_string_in_table(db, &db->subject, lower_word, hit0, NULL);
+        if (do_body) match_string_in_table(db, &db->body, lower_word, hit0, NULL);
+        if (do_att_name) match_string_in_table(db, &db->attachment_name, lower_word, hit0, NULL);
+        if (do_minor_headers) match_string_in_table(db, &db->minor_headers, lower_word, hit0, header_list);
         /* FIXME */
         if (do_path) match_substring_in_paths(db, word, 0, left_anchor, hit0);
       }
 
+      did_minor_headers |= do_minor_headers;
+
       free(lower_word);
+      free(header_list);
 
       /* AND-combine match vectors */
       for (i=0; i<db->n_msgs; i++) {
@@ -1349,6 +1405,15 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
     printf("Matched %d messages\n", n_hits);
   }
   fflush(stdout);
+
+  if (did_minor_headers && !do_index_all_headers && (&db->minor_headers)->n == 0) {
+    fprintf(stderr,
+            "WARNING : \n"
+            "The search expression included a clause to search minor headers,\n"
+            "but \"index_all_headers\" is not in the configuration file, and\n"
+            "the the database has 0 entries in the corresponding table, so\n"
+            "the minorellaneous headers might not actually be indexed.\n");
+  }
 
   if (had_failed_checksum) {
     fprintf(stderr,

--- a/search.c
+++ b/search.c
@@ -291,52 +291,7 @@ static void match_substring_in_table(struct read_db *db, struct toktable_db *tt,
   if (r)  free(r);
   if (nr) free(nr);
 }
-/*}}}*/
-static void match_substring_in_table2(struct read_db *db, struct toktable2_db *tt, char *substring, int max_errors, int left_anchor, char *hits)/*{{{*/
-{
 
-  int i, got_hit;
-  unsigned long a[256];
-  unsigned long *r=NULL, *nr=NULL;
-  unsigned long hit;
-  char *token;
-
-  build_match_vector(substring, a, &hit);
-
-  got_hit = 0;
-  if (max_errors > 3) {
-    r = new_array(unsigned long, 1 + max_errors);
-    nr = new_array(unsigned long, 1 + max_errors);
-  }
-  for (i=0; i<tt->n; i++) {
-    token = db->data + tt->tok_offsets[i];
-    switch (max_errors) {
-      /* Optimise common cases for few errors to allow optimizer to keep bitmaps
-       * in registers */
-      case 0:
-        got_hit = substring_match_0(a, hit, left_anchor, token);
-        break;
-      case 1:
-        got_hit = substring_match_1(a, hit, left_anchor, token);
-        break;
-      case 2:
-        got_hit = substring_match_2(a, hit, left_anchor, token);
-        break;
-      case 3:
-        got_hit = substring_match_3(a, hit, left_anchor, token);
-        break;
-      default:
-        got_hit = substring_match_general(a, hit, left_anchor, token, max_errors, r, nr);
-        break;
-    }
-    if (got_hit) {
-      mark_hits_in_table2(db, tt, i, hits);
-    }
-  }
-  if (r)  free(r);
-  if (nr) free(nr);
-}
-/*}}}*/
 static void match_substring_in_paths(struct read_db *db, char *substring, int max_errors, int left_anchor, char *hits)/*{{{*/
 {
 

--- a/writer.c
+++ b/writer.c
@@ -79,6 +79,7 @@ struct write_map {/*{{{*/
   struct write_map_toktable subject;
   struct write_map_toktable body;
   struct write_map_toktable attachment_name;
+  struct write_map_toktable minor_headers;
   struct write_map_toktable2 msg_ids;
 
   /* To get base address for character data */
@@ -200,6 +201,7 @@ static int char_length(struct database *db)/*{{{*/
   result += toktable_char_length(db->subject);
   result += toktable_char_length(db->body);
   result += toktable_char_length(db->attachment_name);
+  result += toktable_char_length(db->minor_headers);
   result += toktable2_char_length(db->msg_ids);
 
   return result;
@@ -239,6 +241,9 @@ static void compute_mapping(struct database *db, struct write_map *map)/*{{{*/
 
   map->attachment_name.tok_offset = total, total += db->attachment_name->n;
   map->attachment_name.enc_offset = total, total += db->attachment_name->n;
+
+  map->minor_headers.tok_offset = total, total += db->minor_headers->n;
+  map->minor_headers.enc_offset = total, total += db->minor_headers->n;
 
   map->msg_ids.tok_offset = total, total += db->msg_ids->n;
   map->msg_ids.enc0_offset = total, total += db->msg_ids->n;
@@ -299,6 +304,10 @@ static void write_header(char *data, unsigned int *uidata, struct database *db, 
   uidata[UI_ATTACHMENT_NAME_N] = db->attachment_name->n;
   uidata[UI_ATTACHMENT_NAME_TOK] = map->attachment_name.tok_offset;
   uidata[UI_ATTACHMENT_NAME_ENC] = map->attachment_name.enc_offset;
+
+  uidata[UI_MINOR_HEADERS_N] = db->minor_headers->n;
+  uidata[UI_MINOR_HEADERS_TOK] = map->minor_headers.tok_offset;
+  uidata[UI_MINOR_HEADERS_ENC] = map->minor_headers.enc_offset;
 
   uidata[UI_MSGID_N]    = db->msg_ids->n;
   uidata[UI_MSGID_TOK]  = map->msg_ids.tok_offset;
@@ -606,6 +615,7 @@ void write_database(struct database *db, char *filename, int do_integrity_checks
   cdata = write_toktable(db->subject, &map.subject, uidata, data, cdata, "Subject");
   cdata = write_toktable(db->body, &map.body, uidata, data, cdata, "Body");
   cdata = write_toktable(db->attachment_name, &map.attachment_name, uidata, data, cdata, "Attachment Name");
+  cdata = write_toktable(db->minor_headers, &map.minor_headers, uidata, data, cdata, "Minor Headers");
   cdata = write_toktable2(db->msg_ids, &map.msg_ids, uidata, data, cdata, "(Threading)");
 
   /* Write data */


### PR DESCRIPTION
 This is a preliminary implementation (_mairix(1)_ has not be updated but "mairix --help" has been) for https://github.com/rc0/mairix/issues/13 that also fixes https://github.com/vandry/mairix/issues/11. With this change, my database indexing 57,000 emails grew from ~50 MB to ~230 MB, so indexing minor headers is an opt-in feature that must be enabled by adding "index_all_headers" to the mairix configuration file. I'm considering making it possible to select which headers get indexed by explicitly  specifying headers that user does or does not want to be tracked.