### PR TITLE
Fix out of bound array index.

### DIFF
--- a/dfasyn/compdfa.c
+++ b/dfasyn/compdfa.c
@@ -425,7 +425,7 @@ do_next_dfa_state:
 
     for (j=0; j<ntokens; j++) {
       int next_state = dfas[i]->map[j];
-      if (leads_to_result[next_state] == 0) {
+      if (next_state >= 0 && leads_to_result[next_state] == 0) {
         dfas[i]->map[j] = -1;
       }
     }


### PR DESCRIPTION
Check that next_state is defined (i.e. >= 0) before using as an array
index into leads_to_result[].

Fixes core dump when built with gcc7.