### PR TITLE
Fix undefined behaviour due to uninitialized field.

### DIFF
--- a/nvp.c
+++ b/nvp.c
@@ -73,6 +73,7 @@ static void append_name(struct nvp *nvp, char **name)/*{{{*/
   ne = new(struct nvp_entry);
   ne->type = NVP_NAME;
   ne->lhs = *name;
+  ne->rhs = NULL;
   *name = NULL;
   append(nvp, ne);
 }


### PR DESCRIPTION
rhs was not initialized in append_name() but it was almost immediately
accessed in append().