### PR TITLE
Support mbox From lines containing "remote from".

### DIFF
--- a/fromcheck.nfa
+++ b/fromcheck.nfa
@@ -59,6 +59,12 @@ Abbrev DQUOTE = ["]
 Abbrev OTHER_QUOTED = [@:<>]
 Abbrev LEFTSQUARE = [[]
 Abbrev RIGHTSQUARE = [\]]
+Abbrev R = [r]
+Abbrev E = [e]
+Abbrev M = [m]
+Abbrev O = [o]
+Abbrev T = [t]
+Abbrev F = [e]
 
 BLOCK email {
     STATE in
@@ -178,6 +184,18 @@ BLOCK date {
 
 }
 
+BLOCK remote {
+    STATE in
+        WHITE -> in, before_remote
+
+    STATE before_remote
+        R ; E ; M ; O ; T ; E ; WHITE ; F ; R ; O ; M ; WHITE -> host
+
+    STATE host
+        DOMAIN -> host
+        -> out
+}
+
 # Assume the earlier code has identified the '\nFrom ' sequence,
 # and the validator starts scanning from the character beyond the space
 
@@ -197,10 +215,14 @@ BLOCK main {
                         -> before_date
 
     STATE before_date
-        <date:in->out> ; LF = FROMCHECK_PASS
+        <date:in->out> -> opt_remote
 
         # Cope with mozilla mbox format
         <date:in->out> ; CR ; LF = FROMCHECK_PASS
+
+    STATE opt_remote
+        <remote:in->out> ; LF = FROMCHECK_PASS
+        = FROMCHECK_PASS
 
     # Mention this state last : the last mentioned state in the last defined
     # block becomes the entry state of the scanner.

--- a/test/dumps/animals
+++ b/test/dumps/animals
@@ -6,7 +6,7 @@ Dump of database
      3: FILE messages/mh/animals/1, size=1335, tid=0
      4: FILE messages/mh/animals/2, size=1467, tid=0
      5: MBOX 0, msg 0, offset=49, size=1333, tid=0 seen replied
-     6: MBOX 0, msg 1, offset=1431, size=1378, tid=0 seen
+     6: MBOX 0, msg 1, offset=1469, size=1378, tid=0 seen
 
 
 MBOX INFORMATION

--- a/test/dumps/animals-and-AliceBobEve
+++ b/test/dumps/animals-and-AliceBobEve
@@ -6,7 +6,7 @@ Dump of database
      3: FILE messages/mh/animals/1, size=1335, tid=0
      4: FILE messages/mh/animals/2, size=1467, tid=0
      5: MBOX 0, msg 0, offset=49, size=1333, tid=0 seen replied
-     6: MBOX 0, msg 1, offset=1431, size=1378, tid=0 seen
+     6: MBOX 0, msg 1, offset=1469, size=1378, tid=0 seen
      7: FILE messages/mh/AliceBobEve/1, size=279, tid=1
      8: FILE messages/mh/AliceBobEve/2, size=355, tid=2
      9: FILE messages/mh/AliceBobEve/3, size=341, tid=3

--- a/test/dumps/animals-mbox
+++ b/test/dumps/animals-mbox
@@ -1,7 +1,7 @@
 Dump of database
 2 messages
      0: MBOX 0, msg 0, offset=49, size=1333, tid=0 seen replied
-     1: MBOX 0, msg 1, offset=1431, size=1378, tid=0 seen
+     1: MBOX 0, msg 1, offset=1469, size=1378, tid=0 seen
 
 
 MBOX INFORMATION

--- a/test/dumps/animals-removed-maildir
+++ b/test/dumps/animals-removed-maildir
@@ -6,7 +6,7 @@ Dump of database
      3: FILE messages/mh/animals/1, size=1335, tid=0
      4: FILE messages/mh/animals/2, size=1467, tid=0
      5: MBOX 0, msg 0, offset=49, size=1333, tid=0 seen replied
-     6: MBOX 0, msg 1, offset=1431, size=1378, tid=0 seen
+     6: MBOX 0, msg 1, offset=1469, size=1378, tid=0 seen
 
 
 MBOX INFORMATION

--- a/test/dumps/animals-removed-maildir-purged
+++ b/test/dumps/animals-removed-maildir-purged
@@ -3,7 +3,7 @@ Dump of database
      0: FILE messages/mh/animals/1, size=1335, tid=0
      1: FILE messages/mh/animals/2, size=1467, tid=0
      2: MBOX 0, msg 0, offset=49, size=1333, tid=0 seen replied
-     3: MBOX 0, msg 1, offset=1431, size=1378, tid=0 seen
+     3: MBOX 0, msg 1, offset=1469, size=1378, tid=0 seen
 
 
 MBOX INFORMATION

--- a/test/dumps/animals-removed-mh
+++ b/test/dumps/animals-removed-mh
@@ -6,7 +6,7 @@ Dump of database
      3: DEAD
      4: DEAD
      5: MBOX 0, msg 0, offset=49, size=1333, tid=0 seen replied
-     6: MBOX 0, msg 1, offset=1431, size=1378, tid=0 seen
+     6: MBOX 0, msg 1, offset=1469, size=1378, tid=0 seen
 
 
 MBOX INFORMATION

--- a/test/dumps/animals-removed-mh-purged
+++ b/test/dumps/animals-removed-mh-purged
@@ -4,7 +4,7 @@ Dump of database
      1: FILE messages/maildir/animals/cur/1294156254.3884_3.spencer:2,S, size=1259, tid=0 seen
      2: FILE messages/maildir/animals/new/1294156254.3884_5.spencer, size=1366, tid=0
      3: MBOX 0, msg 0, offset=49, size=1333, tid=0 seen replied
-     4: MBOX 0, msg 1, offset=1431, size=1378, tid=0 seen
+     4: MBOX 0, msg 1, offset=1469, size=1378, tid=0 seen
 
 
 MBOX INFORMATION

--- a/test/messages/mbox/animals
+++ b/test/messages/mbox/animals
@@ -33,7 +33,7 @@ Content-Length: 10
 Mouse
 Cat
 
-From someid@some.server Tue Jan  4 16:45:37 2011
+From old-style|uucp|bang|path|server!someid Tue Jan  4 16:45:37 2011 remote from ahost
 Return-Path: <someid@some.server>
 Delivered-To: PFX delivery to someid@some.server
 Received: from pop.pop.domain [212.227.17.169]


### PR DESCRIPTION
This was written by some older mail software (e.g., see
https://www.unix.com/man-page/sunos/1/mail/). One of the tests was
updated to use this format.