### PR TITLE
Fixes to allow the mairix test suite to pass the ASAN and UBSAN analyzers.

### DIFF
--- a/db.c
+++ b/db.c
@@ -218,7 +218,7 @@ struct database *new_database(unsigned int hash_key)/*{{{*/
     {
       gettimeofday(&tv, NULL);
       pid = getpid();
-      hash_key = tv.tv_sec ^ (pid ^ (tv.tv_usec << 15));
+      hash_key = tv.tv_sec ^ (pid ^ ((unsigned)tv.tv_usec << 15));
     }
   result->hash_key = hash_key;
 

--- a/db.c
+++ b/db.c
@@ -264,6 +264,7 @@ void free_database(struct database *db)/*{{{*/
     free(db->type);
   }
 
+  free_mboxen(db);
   free(db);
 }
 /*}}}*/
@@ -462,13 +463,19 @@ struct database *new_database_from_file(char *db_filename, int do_integrity_chec
     result->mboxen[i].file_size  = input->mbox_size_table[i];
     nn = result->mboxen[i].n_msgs = input->mbox_entries_table[i];
     result->mboxen[i].max_msgs = nn;
-    result->mboxen[i].start = new_array(off_t, nn);
-    result->mboxen[i].len   = new_array(size_t, nn);
-    result->mboxen[i].check_all = new_array(checksum_t, nn);
-    /* Copy the entire checksum table in one go. */
-    memcpy(result->mboxen[i].check_all,
-           input->data + input->mbox_checksum_table[i],
-           nn * sizeof(checksum_t));
+    if (nn > 0) {
+      result->mboxen[i].start = new_array(off_t, nn);
+      result->mboxen[i].len   = new_array(size_t, nn);
+      result->mboxen[i].check_all = new_array(checksum_t, nn);
+      /* Copy the entire checksum table in one go. */
+      memcpy(result->mboxen[i].check_all,
+             input->data + input->mbox_checksum_table[i],
+             nn * sizeof(checksum_t));
+    } else {
+      result->mboxen[i].start = NULL;
+      result->mboxen[i].len   = NULL;
+      result->mboxen[i].check_all = NULL;
+    }
     result->mboxen[i].n_so_far = 0;
   }
 

--- a/dirscan.c
+++ b/dirscan.c
@@ -355,7 +355,7 @@ void build_message_list(char *folder_base, char *folders, enum folder_type ft,
     struct msgpath_array *msgs,
     struct globber_array *omit_globs)
 {
-  char **raw_paths, **paths;
+  char **raw_paths, **paths = NULL;
   int n_raw_paths, n_paths, i;
 
   split_on_colons(folders, &n_raw_paths, &raw_paths);
@@ -377,7 +377,8 @@ void build_message_list(char *folder_base, char *folders, enum folder_type ft,
       break;
   }
 
-  if (paths) free(paths);
+  free_string_array(n_raw_paths, &raw_paths);
+  free_string_array(n_paths, &paths);
 
   return;
 }

--- a/glob.c
+++ b/glob.c
@@ -283,6 +283,16 @@ void string_list_to_array(struct string_list *list, int *n, char ***arr)/*{{{*/
   *arr = result;
 }
 /*}}}*/
+void free_string_array(int n, char ***arr) /*{{{*/
+{
+    int i;
+    for (i=0; i<n; ++i) {
+        free((*arr)[i]);
+    }
+    free(*arr);
+    *arr = NULL;
+}
+/*}}}*/
 void split_on_colons(const char *str, int *n, char ***arr)/*{{{*/
 {
   struct string_list list, *new_cell;

--- a/mairix.c
+++ b/mairix.c
@@ -128,6 +128,10 @@ int member_of (const char *complete_mfolder,
     if (mfolder_sb.st_ino == src_folder_sb.st_ino)
       return 1;
   }
+
+  free_string_array(n_raw_paths, &raw_paths);
+  free_string_array(n_paths, &paths);
+
   return 0;
 }
 /*}}}*/

--- a/mairix.c
+++ b/mairix.c
@@ -304,7 +304,8 @@ static int message_compare(const void *a, const void *b)/*{{{*/
 /*}}}*/
 static void sort_message_list(struct msgpath_array *arr)/*{{{*/
 {
-  qsort(arr->paths, arr->n, sizeof(struct msgpath), message_compare);
+  if (arr->paths)
+    qsort(arr->paths, arr->n, sizeof(struct msgpath), message_compare);
 }
 /*}}}*/
 

--- a/mairix.h
+++ b/mairix.h
@@ -309,6 +309,7 @@ int is_glob_match(struct globber *g, const char *s);
 struct globber_array *colon_sep_string_to_globber_array(const char *in);
 int is_globber_array_match(struct globber_array *ga, const char *s);
 void free_globber_array(struct globber_array *in);
+void free_string_array(int n, char ***arr);
 
 /* In hash.c */
 unsigned int hashfn( unsigned char *k, unsigned int length, unsigned int initval);
@@ -376,6 +377,7 @@ unsigned int encode_mbox_indices(unsigned int mb, unsigned int msg);
 void decode_mbox_indices(unsigned int index, unsigned int *mb, unsigned int *msg);
 int verify_mbox_size_constraints(struct database *db);
 void glob_and_expand_paths(const char *folder_base, char **paths_in, int n_in, char ***paths_out, int *n_out, const struct traverse_methods *methods, struct globber_array *omit_globs);
+void free_mboxen(struct database *db);
 
 /* In glob.c */
 struct globber;

--- a/mbox.c
+++ b/mbox.c
@@ -435,6 +435,15 @@ static void deaden_mbox(struct mbox *mb)/*{{{*/
   }
 }
 /*}}}*/
+void free_mboxen(struct database *db)/*{{{*/
+{
+  int i;
+  for (i=0; i<db->n_mboxen; i++) {
+    deaden_mbox(&db->mboxen[i]);
+  }
+  free(db->mboxen);
+}
+/*}}}*/
 static void marry_up_mboxen(struct database *db, struct extant_mbox *extant_mboxen, int n_extant)/*{{{*/
 {
   int *old_to_new_idx;
@@ -802,6 +811,7 @@ void build_mbox_lists(struct database *db, const char *folder_base, /*{{{*/
   if (mboxen_paths) {
     split_on_colons(mboxen_paths, &n_raw_paths, &raw_paths);
     glob_and_expand_paths(folder_base, raw_paths, n_raw_paths, &paths, &n_paths, &mbox_traverse_methods, omit_globs);
+    free_string_array(n_raw_paths, &raw_paths);
     extant_mboxen = new_array(struct extant_mbox, n_paths);
   } else {
     n_paths = 0;
@@ -847,6 +857,9 @@ void build_mbox_lists(struct database *db, const char *folder_base, /*{{{*/
   check_duplicates(extant_mboxen, n_extant);
 
   marry_up_mboxen(db, extant_mboxen, n_extant);
+  for (i=0; i < n_extant; ++i)
+      free(extant_mboxen[i].full_path);
+  free(extant_mboxen);
 
   /* Now look for new/modified mboxen, find how many of the old messages are
    * still valid and scan the remainder. */

--- a/nvp.c
+++ b/nvp.c
@@ -332,16 +332,8 @@ void free_nvp(struct nvp *nvp)/*{{{*/
   struct nvp_entry *ne, *nne;
   for (ne = nvp->first; ne; ne=nne) {
     nne = ne->next;
-    switch (ne->type) {
-      case NVP_NAME:
-        free(ne->lhs);
-        break;
-      case NVP_MAJORMINOR:
-      case NVP_NAMEVALUE:
-        free(ne->lhs);
-        free(ne->rhs);
-        break;
-    }
+    free(ne->lhs);
+    free(ne->rhs);
     free(ne);
   }
   free(nvp);

--- a/nvp.c
+++ b/nvp.c
@@ -137,16 +137,8 @@ static void release_nvp(struct nvp *nvp)/*{{{*/
   struct nvp_entry *e, *ne;
   for (e=nvp->first; e; e=ne) {
     ne = e->next;
-    switch (e->type) {
-      case NVP_NAME:
-        free(e->lhs);
-        break;
-      case NVP_MAJORMINOR:
-      case NVP_NAMEVALUE:
-        free(e->lhs);
-        free(e->rhs);
-        break;
-    }
+    free(e->lhs);
+    free(e->rhs);
     free(e);
   }
   free(nvp);
@@ -202,7 +194,8 @@ struct nvp *make_nvp(struct msg_src *src, char *s, const char *pfx)/*{{{*/
           pfx, s, format_msg_src(src));
 #endif
       release_nvp(result);
-      return NULL;
+      result = NULL;
+      goto out;
     }
 
     if (nvp_copier[current_state] != last_copier) {

--- a/writer.c
+++ b/writer.c
@@ -556,7 +556,8 @@ static char *write_toktable2(struct toktable2 *tab, struct write_map_toktable2 *
     int dlen;
     dlen = stok[i]->match1.n;
     uidata[map->enc1_offset + i] = cdata - data;
-    memcpy(cdata, stok[i]->match1.msginfo, dlen);
+    if (dlen)
+      memcpy(cdata, stok[i]->match1.msginfo, dlen);
     cdata += dlen;
     *cdata++ = 0xff; /* termination character */
   }


### PR DESCRIPTION
Enabling ASAN and UBSAN during regression tests can help find more problems
with the code.  The dfasyn program still has issues, but given that it's only a
build-time dependency, fixing it isn't as high a priority.