### PR TITLE
Fix parsing to not skip NUL characters

### DIFF
--- a/nvp.c
+++ b/nvp.c
@@ -272,8 +272,11 @@ struct nvp *make_nvp(struct msg_src *src, char *s, const char *pfx)/*{{{*/
           case GOT_NAMEVALUE_CCONT:
 	    for(tempsrc = tempdst = value; *tempsrc; tempsrc++) {
 		if (*tempsrc == '%') {
-		    int val = hex_to_val(*++tempsrc) << 4;
-		    val |= hex_to_val(*++tempsrc);
+		    int val = -1;
+		    if (tempsrc[1] && tempsrc[2]) {
+			val = hex_to_val(*++tempsrc) << 4;
+			val |= hex_to_val(*++tempsrc);
+		    }
 		    if (val < 0) {
 #ifdef TEST
 			fprintf(stderr, "'%s' could not be parsed (%%)\n", s);

--- a/rfc822.c
+++ b/rfc822.c
@@ -958,7 +958,7 @@ static time_t parse_rfc822_date(char *date_string)/*{{{*/
   else if (!strncasecmp(s, "dec", 3)) tm.tm_mon = 11;
   else goto tough_cheese;
 
-  while (!isspace(*s)) s++;
+  while (*s && !isspace(*s)) s++;
   while (*s && isspace(*s)) s++;
   if (!isdigit(*s)) goto tough_cheese;
   tm.tm_year = atoi(s);
@@ -1056,9 +1056,9 @@ struct rfc822 *data_to_rfc822(struct msg_src *src,
     else if (!result->hdrs.references && match_string("references:", x->text))
       result->hdrs.references = copy_header_value(x->text);
     else if (match_string("status:", x->text))
-      scan_status_flags(x->text + sizeof("status:"), &result->hdrs);
+      scan_status_flags(x->text + (sizeof("status:") - 1), &result->hdrs);
     else if (match_string("x-status:", x->text))
-      scan_status_flags(x->text + sizeof("x-status:"), &result->hdrs);
+      scan_status_flags(x->text + (sizeof("x-status:") - 1), &result->hdrs);
   }
 /*}}}*/
 


### PR DESCRIPTION
This should fix a bug that was reported for the Fedora mairix package and few other instances of this issue that were found by fuzzing with AFL++.