### PR TITLE
Fix cache/sort bug

### DIFF
--- a/search.c
+++ b/search.c
@@ -859,7 +859,6 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
   int imap_tried = 0;
   struct imap_ll *imapc;
   searchResult *results;
-  searchResult *cur;
 
 #define GET_IMAP if (!imap_tried) {\
         imap_tried = 1;\
@@ -1121,7 +1120,9 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
 
   results = new_array(searchResult, db->n_msgs);
   if (sort_by_date) {
-    for (cur=results,i=0; i<db->n_msgs; i++) {
+    searchResult *cur = results;
+
+    for (i=0; i<db->n_msgs; i++) {
       results[i].m_seq_num = -1;
       if (hit3[i] && rd_msg_type(db, i) != DB_MSG_DEAD) {
         cur->m_db_id = i;
@@ -1136,11 +1137,11 @@ static int do_search(struct read_db *db, char **args, char *output_path, int sho
   } else {
     n_hits = 0;
     for (i=0; i<db->n_msgs; i++) {
-      if (hit3[i] && rd_msg_type(db, i) != DB_MSG_DEAD)
+      if (hit3[i] && rd_msg_type(db, i) != DB_MSG_DEAD) {
+        ++n_hits;
         results[i].m_seq_num = i;
-      else
+      } else
         results[i].m_seq_num = -1;
-      ++n_hits;
     }
   }
 


### PR DESCRIPTION
Low priority, just putting this out there in case useful..

So I've been using this patch for oh it seems five years and maybe it should be published.  I've kindof forgotten what the *exact* problem is, but looking at my original commit comment it appears that maybe retrieving messages to fill the results folder _in sort order_ was causing cache problems as we bounced backwards and forwards between different indexed archive files, so now we fill the results folder in cache order; the extra code ensures we can do this and number the files correctly anyway.

---

Ah.  Here's a more detailed note I wrote at the time:

> It always seemed like it might be best to write out search results in DB order, even if they're sequenced differently (i.e. sort in a different order on disc): that way multiple results from the same mbox/whatever would use the same cached mmap; however I was lazy and didn't do that first time around.  This actually triggers a cache-clearing bug when bouncing back and forth between compressed and non-compressed mboxen, so this patch does the job properly after all.
>                                                   
> Problem is if result 1 is from a.mbox.gz, 2 from b.mbox, and 3 from a.mbox.gz, then since the mmap cache is only set/cleared for *compressed* files, the attempt to get message 3 *expects* the cache to still contain a.mbox, but mapping b.mbox seems to have cleared it without clearing the cache entry.  That's probably a bug, but it can be avoided by the above, which will retrieve 1 and 3 first (because they're both in the bunch of messages indexed from a.mbox.gz), then get 2.